### PR TITLE
Emit a warning chemical when arbitrary chemicals without handlers/listeners are emitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,37 @@ plasma.on(Class1, function (instance) {
 var instance = new Class1()
 plasma.emit(instance)
 ```
+
+### notification of missing listeners/handlers for a chemical
+
+* When emitting a chemical (via the `.emit` method) which has no registered handlers (via the `.on`/`.once` methods) a warning chemical will be emitted (by default its type is `plasma/missingHandler`)
+
+```
+instance.on("plasma/missingHandler", function(c){
+  ...
+  expect(c).toBe({
+    type: 'plasma/missingHandler',
+    chemical: {
+      type: chemicalWithNoHandler,
+      someData: true
+    }
+  })
+  ...
+})
+
+instance.emit({
+  type: "chemicalWithNoHandler",
+  someData: true
+})
+```
+
+* The missing handlers warning chemical will not be emitted when storing chemicals.
+* The type of the missing handlers warning chemical can be customized when instantiating the plasma
+
+```
+var instance  = new Plasma({
+  missingHandlersChemical: 'someChemicalType'
+})
+
+instance.on("someChemicalType", function(c){ ... })
+```

--- a/index.js
+++ b/index.js
@@ -1,11 +1,15 @@
 var Plasma = require('organic').Plasma
 var utils = require('./lib/utils')
 
-var Plasma = module.exports = function(){
+var Plasma = module.exports = function(opts){
   this.listeners = []
   this.remoteSubscribers = []
   this.storedChemicals = []
   this.utils = utils
+  this.opts = opts || {}
+  if (!this.opts.missingHandlersChemical) {
+    this.opts.missingHandlersChemical = "plasma/missingHandler"
+  }
 }
 
 module.exports.prototype = Object.create(Plasma.prototype)
@@ -175,9 +179,9 @@ module.exports.prototype.emit = function (chemical) {
     }
   }
 
-  if (!hasListeners && !this.utils.isChemicalInSet(chemical, this.storedChemicals) && chemical.type !== 'plasma/missingHandler') {
+  if (!hasListeners && !this.utils.isChemicalInSet(chemical, this.storedChemicals) && chemical.type !== this.opts.missingHandlersChemical) {
     this.emit({
-      type: 'plasma/missingHandler',
+      type: this.opts.missingHandlersChemical,
       chemical: chemical
     })
     return

--- a/index.js
+++ b/index.js
@@ -159,9 +159,11 @@ module.exports.prototype.emit = function (chemical) {
   this.notifySubscribers(chemical)
 
   var listenersCount = this.listeners.length
+  var hasListeners = false
   for(var i = 0; i<listenersCount && i<this.listeners.length; i++) {
     var listener = this.listeners[i]
     if(this.utils.deepEqual(listener.pattern, chemical)) {
+      hasListeners = true
       if(listener.once) {
         this.listeners.splice(i, 1);
         i -= 1;
@@ -171,5 +173,13 @@ module.exports.prototype.emit = function (chemical) {
       var aggregated = listener.handler.call(listener.context, chemical, function noop () {})
       if (aggregated === true) return // halt chemical transfer, it has been aggregated
     }
+  }
+
+  if (!hasListeners && !this.utils.isChemicalInSet(chemical, this.storedChemicals) && chemical.type !== 'plasma/missingHandler') {
+    this.emit({
+      type: 'plasma/missingHandler',
+      chemical: chemical
+    })
+    return
   }
 }

--- a/tests/onemit.spec.js
+++ b/tests/onemit.spec.js
@@ -25,4 +25,25 @@ describe("plasma on / emit feature", function(){
       someData: true
     })
   })
+
+  it("customizing the missing handler warning chemical type", function(done){
+    var opts = {
+      missingHandlersChemical: "plasma/customWarningChemical"
+    }
+    var instance  = new Plasma(opts)
+
+    instance.on(opts.missingHandlersChemical, function(c){
+      expect(c.type).toBe(opts.missingHandlersChemical)
+      expect(c.chemical).toEqual({
+        type: "c2",
+        someData: true
+      })
+      done()
+    })
+
+    instance.emit({
+      type: "c2",
+      someData: true
+    })
+  })
 })

--- a/tests/onemit.spec.js
+++ b/tests/onemit.spec.js
@@ -9,4 +9,20 @@ describe("plasma on / emit feature", function(){
     })
     instance.emit({type: "c1"})
   })
+
+  it("'emit' with missing 'on' results in emiting a warning chemical", function(done){
+    var instance  = new Plasma()
+    instance.on("plasma/missingHandler", function(c){
+      expect(c.type).toBe("plasma/missingHandler")
+      expect(c.chemical).toEqual({
+        type: "c2",
+        someData: true
+      })
+      done()
+    })
+    instance.emit({
+      type: "c2",
+      someData: true
+    })
+  })
 })

--- a/tests/pipe.spec.js
+++ b/tests/pipe.spec.js
@@ -2,8 +2,13 @@ describe("plasma pipe feature", function(){
   var Plasma = require("../index")
   var instance  = new Plasma()
   it("pipes all chemicals to destination Fn", function(done){
+    var pipeHit = false
     instance.pipe(function(c){
       expect(c.type).toBe("c1")
+      pipeHit = true
+    })
+    instance.on("c1", function () {
+      expect(pipeHit).toBe(true)
       done()
     })
     instance.emit({type: "c1"})

--- a/tests/store-trash.spec.js
+++ b/tests/store-trash.spec.js
@@ -44,7 +44,7 @@ describe("plasma trash feature", function(){
     instance.trashAll({type: "c1"})
   })
 
-  it("stores and trash", function(){
+  it("stores without emit warning chemical for missing handlers", function(){
     var missingHandlerWarning = false
     instance.on("plasma/missingHandler", function (c) {
       missingHandlerWarning = true
@@ -53,6 +53,19 @@ describe("plasma trash feature", function(){
 
     var chemical = {type: "c1"}
     instance.store(chemical)
+    expect(instance.has(chemical)).toBe(true)
+    expect(missingHandlerWarning).toBe(false)
+  })
+
+  it("storeAndOverrides without emit warning chemical for missing handlers", function(){
+    var missingHandlerWarning = false
+    instance.on("plasma/missingHandler", function (c) {
+      missingHandlerWarning = true
+      throw new Error("'plasma/missingHandler' should not be emitted")
+    })
+
+    var chemical = {type: "c1"}
+    instance.storeAndOverride(chemical)
     expect(instance.has(chemical)).toBe(true)
     expect(missingHandlerWarning).toBe(false)
   })

--- a/tests/store-trash.spec.js
+++ b/tests/store-trash.spec.js
@@ -44,4 +44,16 @@ describe("plasma trash feature", function(){
     instance.trashAll({type: "c1"})
   })
 
+  it("stores and trash", function(){
+    var missingHandlerWarning = false
+    instance.on("plasma/missingHandler", function (c) {
+      missingHandlerWarning = true
+      throw new Error("'plasma/missingHandler' should not be emitted")
+    })
+
+    var chemical = {type: "c1"}
+    instance.store(chemical)
+    expect(instance.has(chemical)).toBe(true)
+    expect(missingHandlerWarning).toBe(false)
+  })
 })


### PR DESCRIPTION
# General

**This PR resolves issue #3**

This PR brings on board a mechanism allowing the plasma to notify (via its own interface) when a chemical has been emitted but there is no listener/handler for it. This mis-behaviour usually is hard to debug/trace and results with the callback function never being executed (when using https://github.com/outbounder/organic-plasma-feedback).

When this happens the plasma will emit a chemical of the `plasma/missingHandler` (user configurable) which will bear the original chemical. On the user side this chemical can be handled (via the `on`/`once` handlers) and a error can be thrown / logged in the console.

# Future improvements

* A generic `plasma/warning` chemical can be used instead of `plasma/missingHandler` with a structure similar to:

```
{
  type: 'plasma/warning',
  warningType: 'missingHandler',
  chemical: { ... } 
}
```
* https://github.com/outbounder/organic-plasma-feedback can be extended to run the callback function / resolve the promise with an error if no handlers for the chemical are present.