### PR TITLE
merge organic-plasma-feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ Upgrade path requires removing `organic-plasma-feedback` decoration as feedback 
 ### Changed
 - `plasma.on` - supports feedback callback
 - `plasma.on(array)` - supports feedback callback
-- `plasma.emit` - supports feedback callback
+- `plasma.emit` - supports feedback callback, returns `true` Boolean value when chemical has been aggregated
 - removed `context` argument from `plasma.on`, `plasma.onAll`, `plasma.once`
 
 ### Fixed
 
 - jasmine test specs
+- plasma.emit to return true when chemical has been aggregated
 
 ## [1.2.2] - 2017-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.0] - ToBeReleased
+
+**The release contains breaking changes towards v1.x.x**
+Upgrade path requires removing `organic-plasma-feedback` decoration as feedback support is re-implemented in organic-plasma module
+
+### Changed
+- `plasma.on` - supports feedback callback
+- `plasma.on(array)` - supports feedback callback
+- `plasma.emit` - supports feedback callback
+- removed `context` argument from `plasma.on`, `plasma.onAll`, `plasma.once`
+
+### Fixed
+
+- jasmine test specs
+
 ## [1.2.2] - 2017-02-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.0.0] - ToBeReleased
+## [2.0.0] - [ToBeReleased]
 
 **The release contains breaking changes towards v1.x.x**
 Upgrade path requires removing `organic-plasma-feedback` decoration as feedback support is re-implemented in organic-plasma module
 
 ### Changed
+
 - `plasma.on` - supports feedback callback
 - `plasma.on(array)` - supports feedback callback
 - `plasma.emit` - supports feedback callback, returns `true` Boolean value when chemical has been aggregated
-- `plasma.off` - supports `handler` form in addition to `pattern` + function `handler`
+- `plasma.off` - added additional support for single `handler` form
 - `plasma.store` - supports String chemicals
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Upgrade path requires removing `organic-plasma-feedback` decoration as feedback 
 - `plasma.on(array)` - supports feedback callback
 - `plasma.emit` - supports feedback callback, returns `true` Boolean value when chemical has been aggregated
 - `plasma.off` - supports `handler` only form in addition to `pattern` + function `handler`
+- `plasma.store` - supports String chemicals
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Upgrade path requires removing `organic-plasma-feedback` decoration as feedback 
 - `plasma.on` - supports feedback callback
 - `plasma.on(array)` - supports feedback callback
 - `plasma.emit` - supports feedback callback, returns `true` Boolean value when chemical has been aggregated
-- `plasma.off` - supports `handler` only form in addition to `pattern` + function `handler`
+- `plasma.off` - supports `handler` form in addition to `pattern` + function `handler`
 - `plasma.store` - supports String chemicals
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Upgrade path requires removing `organic-plasma-feedback` decoration as feedback 
 - `plasma.on` - supports feedback callback
 - `plasma.on(array)` - supports feedback callback
 - `plasma.emit` - supports feedback callback, returns `true` Boolean value when chemical has been aggregated
-- removed `context` argument from `plasma.on`, `plasma.onAll`, `plasma.once`
+- `plasma.off` - supports `handler` only form in addition to `pattern` + function `handler`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ ___arguments___
   * as `String` equals to `{ type: String, ... }` Chemical
   * as `Object` equals to Chemical
 
+___returns___
+
+* `true` - *only* when chemical has been aggregated
+
 ### plasma.store(c)
 
 Does the same as `plasma.emit` but also triggers any
@@ -99,7 +103,7 @@ plasma.on('c1', function reaction1 () {
 plasma.on('c1', function reaction2 () {
   // won't be reached, reaction1 aggregated the chemical
 })
-plasma.emit('c1')
+console.log(plasma.emit('c1')) // === true
 ```
 
 ### optional usage of arguments

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ ___arguments___
 
 The same as `plasma.on([p1, p2], function(c1, c2){})` but will trigger the function only once.
 
-### plasma.off(pattern, function)
+### plasma.off(pattern, function, context)
 
 Unregisters chemical reaction functions, the opposite of `plasma.on` or `plasma.once`.
 
@@ -96,6 +96,7 @@ ___arguments___
   * as `String` or `Array` or `Object` - needs function handler for unregister to succeed
   * as `Function` - finds **all** registered chemical reactions with that function handler and unregisters them.
 * `function` *optional* required only when `pattern` is String, Array or Object. This should be the exact function used for `plasma.on` or `plasma.once`
+* `context` *optional* used to scope removing of chemical reactions within context
 
 ### plasma.trash(c)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Plasma v1.2.2
+# Plasma v2.0.0
 
 Implementation of [node-organic/Plasma v1.0.0](https://github.com/VarnaLab/node-organic/blob/master/docs/Plasma.md).
 
 ## Public API
 
-### plasma.emit(c)
+### plasma.emit(c [, data, callback])
 
 Immediatelly triggers any reactions matching given `c` chemical.
 
@@ -37,7 +37,7 @@ Returns synchroniously first found stored chemical by given pattern.
 
 Returns synchroniously stored chemicals by given pattern.
 
-### plasma.on(pattern, function (c){} [, context])
+### plasma.on(pattern, function (c [, callback]){})
 
 Registers a function to be triggered when chemical emitted in plasma matches given pattern.
 
@@ -46,13 +46,12 @@ ___arguments___
   * as `String` matching `Chemical.type` property
   * as `Object` matching one or many properties of `Chemical`
 * `c` - `Object` Chemical matching `pattern`
-* `context` *optional* - will be used to invoke for function's context
 
-### plasma.once(pattern, function (c){} [, context])
+### plasma.once(pattern, function (c [, callback]){})
 
 The same as `plasma.on(pattern, function reaction (c){})` but will trigger the function only once.
 
-### plasma.on([p1, p2, ...], function (c1, c2, ...){} [, context])
+### plasma.on([p1, p2, ...], function (c1, c2, ...){})
 
 Registers a function to be triggered when all chemicals emitted in plasma have been matched.
 
@@ -62,9 +61,8 @@ ___arguments___
   * having elements `Object` matching one or many properties of `Chemical`
 * `c` - array
   * `Object` Chemicals matching `p` array maintaining their index order
-* `context` *optional* - will be used to invoke for function's context
 
-### plasma.once([p1, p2], function (c1, c2) {} [, context])
+### plasma.once([p1, p2, ...], function (c1, c2, ...) {})
 
 The same as `plasma.on([p1, p2], function(c1, c2){})` but will trigger the function only once.
 
@@ -118,9 +116,16 @@ triggers **all** the following:
 
 ### feedback support
 
-* [organic-plasma-feedback](https://github.com/outbounder/organic-plasma-feedback)
+```
+plasma.on('c1', function reaction1 (c, callback) {
+  callback(c)
+})
+plasma.emit('c1', function callback (c) {
+  // c.type === 'c1'
+})
+```
 
-### custom pattern <-> chemical match algoritms
+### custom pattern <-> chemical match algorithms
 
 * override `plasma.utils.deepEqual(pattern, chemical)`
 

--- a/README.md
+++ b/README.md
@@ -40,19 +40,15 @@ ___returns___
 ### plasma.has(pattern) : boolean
 ___returns___
 
-* `true` - *only* when chemical has been aggregated
-Checks synchroniously for stored chemicals by given pattern.
+Checks synchronously for stored chemicals by given pattern.
 
 ### plasma.get(pattern) : Chemical
 
-Returns synchroniously first found stored chemical by given pattern.
-___returns___
-
-* `true` - *only* when chemical has been aggregated
+Returns synchronously first found stored chemical by given pattern.
 
 ### plasma.getAll(pattern) : Array [ Chemical ]
 
-Returns synchroniously stored chemicals by given pattern.
+Returns synchronously all stored chemicals by given pattern.
 
 ### plasma.on(pattern, function (c [, callback]){} [, context])
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Implementation of [node-organic/Plasma v1.0.0](https://github.com/VarnaLab/node-
 
 ## Public API
 
-### plasma.emit(c [, data, callback])
+### plasma.emit(c [, data, callback]) : Boolean
 
 Immediatelly triggers any reactions matching given `c` chemical.
 
@@ -17,31 +17,44 @@ ___returns___
 
 * `true` - *only* when chemical has been aggregated
 
-### plasma.store(c)
+### plasma.store(c) : Boolean
 
 Does the same as `plasma.emit` but also triggers any
 reactions registered in the future using `plasma.on`
 
-### plasma.storeAndOverride(c)
+___returns___
+
+* `true` - *only* when chemical has been aggregated
+
+### plasma.storeAndOverride(c) : Boolean
 
 Does the same as `plasma.emit` but also triggers any
 reactions registered in the future using `plasma.on`.
 
 It overrides previously stored chemicals having the same chemical using `c.type`
 
-### plasma.has(pattern) : boolean
+___returns___
 
+* `true` - *only* when chemical has been aggregated
+
+### plasma.has(pattern) : boolean
+___returns___
+
+* `true` - *only* when chemical has been aggregated
 Checks synchroniously for stored chemicals by given pattern.
 
 ### plasma.get(pattern) : Chemical
 
 Returns synchroniously first found stored chemical by given pattern.
+___returns___
+
+* `true` - *only* when chemical has been aggregated
 
 ### plasma.getAll(pattern) : Array [ Chemical ]
 
 Returns synchroniously stored chemicals by given pattern.
 
-### plasma.on(pattern, function (c [, callback]){})
+### plasma.on(pattern, function (c [, callback]){} [, context])
 
 Registers a function to be triggered when chemical emitted in plasma matches given pattern.
 
@@ -50,12 +63,14 @@ ___arguments___
   * as `String` matching `Chemical.type` property
   * as `Object` matching one or many properties of `Chemical`
 * `c` - `Object` Chemical matching `pattern`
+* `callback` - *optional* callback function used for feedback
+* `context` - *optional* context to be used for calling the function
 
-### plasma.once(pattern, function (c [, callback]){})
+### plasma.once(pattern, function (c [, callback]){} [, context])
 
 The same as `plasma.on(pattern, function reaction (c){})` but will trigger the function only once.
 
-### plasma.on([p1, p2, ...], function (c1, c2, ...){})
+### plasma.on([p1, p2, ...], function (c1, c2, ...){} [, context])
 
 Registers a function to be triggered when all chemicals emitted in plasma have been matched.
 
@@ -65,14 +80,22 @@ ___arguments___
   * having elements `Object` matching one or many properties of `Chemical`
 * `c` - array
   * `Object` Chemicals matching `p` array maintaining their index order
+* `context` - *optional* context to be used for calling the function
 
-### plasma.once([p1, p2, ...], function (c1, c2, ...) {})
+### plasma.once([p1, p2, ...], function (c1, c2, ...) {} [, context])
 
 The same as `plasma.on([p1, p2], function(c1, c2){})` but will trigger the function only once.
 
 ### plasma.off(pattern, function)
 
 Unregisters chemical reaction functions, the opposite of `plasma.on` or `plasma.once`.
+
+___arguments___
+
+* `pattern`
+  * as `String` or `Array` or `Object` - needs function handler for unregister to succeed
+  * as `Function` - finds **all** registered chemical reactions with that function handler and unregisters them.
+* `function` *optional* required only when `pattern` is String, Array or Object. This should be the exact function used for `plasma.on` or `plasma.once`
 
 ### plasma.trash(c)
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports.prototype.on = function (pattern, handler, context, once) {
       var chemical = this.storedChemicals[i]
       if(this.utils.deepEqual(pattern, chemical)) {
         handlerExecuted = true
-        handler(chemical)
+        handler.call(context, chemical)
       }
     }
 
@@ -84,6 +84,9 @@ module.exports.prototype.off = function (pattern, handler) {
 }
 
 module.exports.prototype.store = function (chemical) {
+  if (typeof chemical == "string") {
+    chemical = {type: chemical}
+  }
   this.storedChemicals.push(chemical)
   return this.emit(chemical)
 }

--- a/index.js
+++ b/index.js
@@ -61,13 +61,15 @@ module.exports.prototype.once = function (pattern, handler, context) {
   this.on(pattern, handler, context, true)
 }
 
-module.exports.prototype.off = function (pattern, handler) {
-  if (pattern && handler) {
+module.exports.prototype.off = function (pattern, handler, context) {
+  if (typeof pattern !== 'function') {
     if (typeof pattern == "string") {
       pattern = {type: pattern}
     }
     for(var i = 0; i<this.listeners.length; i++) {
-      if(this.utils.deepEqual(this.listeners[i].pattern, pattern) && this.listeners[i].handler == handler) {
+      if(this.utils.deepEqual(this.listeners[i].pattern, pattern) &&
+        this.listeners[i].handler === handler &&
+        this.listeners[i].context === context) {
         this.listeners.splice(i, 1)
         i -= 1
       }
@@ -75,7 +77,7 @@ module.exports.prototype.off = function (pattern, handler) {
   } else
   if (typeof pattern === 'function') {
     for(var i = 0; i<this.listeners.length; i++) {
-      if(this.listeners[i].handler == pattern) {
+      if(this.listeners[i].handler === pattern && this.listeners[i].context === handler) {
         this.listeners.splice(i, 1)
         i -= 1
       }

--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ module.exports.prototype.emit = function (chemical, callback) {
       }
 
       var aggregated = listener.handler(chemical, callback || function noop () {})
-      if (aggregated === true) return // halt chemical transfer, it has been aggregated
+      if (aggregated === true) return true // halt chemical transfer, it has been aggregated
     }
   }
 

--- a/tests/aggregate.spec.js
+++ b/tests/aggregate.spec.js
@@ -1,0 +1,14 @@
+describe("plasma aggregate feature", function(){
+  var Plasma = require("../index")
+  var instance  = new Plasma()
+  it("aggregate chemical", function(){
+    instance.on('c1', function (c) {
+      expect(c.type).toBe('c1')
+      return true
+    })
+    instance.on('c1', function () {
+      throw new Error('should be called')
+    })
+    expect(instance.emit({type: "c1"})).toBe(true)
+  })
+})

--- a/tests/chemical-instances.spec.js
+++ b/tests/chemical-instances.spec.js
@@ -6,7 +6,7 @@ describe("chemical as instances", function(){
   }
   it("matches by chemical isntance class types", function(done){
     instance.on(Class1, function(c){
-      expect(c.test).to.eq(1)
+      expect(c.data.test).toBe(1)
       done()
     })
     instance.emit(new Class1({test: 1}))

--- a/tests/context-edge-case.spec.js
+++ b/tests/context-edge-case.spec.js
@@ -1,0 +1,32 @@
+describe('maintain class method context on all chemicals', function(){
+  var Plasma = require("../index")
+  it("invokes class method via onAll and keeps its context binded", function(done){
+    var instance  = new Plasma()
+    var Class1 = function (plasma) {
+      plasma.on(['c1', 'c2'], this.handleAllMethod.bind(this))
+    }
+    Class1.prototype.handleAllMethod = function (c1, c2) {
+      expect(c1.type).toBe('c1')
+      expect(c2.type).toBe('c2')
+      expect(this).toBe(classInstance)
+      done()
+    }
+    var classInstance = new Class1(instance)
+    instance.emit('c1')
+    instance.emit('c2')
+  })
+
+  it('invokes class method via on and keeps its context binded', function(done) {
+    var instance  = new Plasma()
+    var Class2 = function (plasma) {
+      plasma.on('c1', this.handlerMethod.bind(this))
+    }
+    Class2.prototype.handlerMethod = function (c1) {
+      expect(c1.type).toBe('c1')
+      expect(this).toBe(classInstance)
+      done()
+    }
+    var classInstance = new Class2(instance)
+    instance.emit('c1')
+  })
+})

--- a/tests/context.spec.js
+++ b/tests/context.spec.js
@@ -2,8 +2,7 @@ describe('maintain class method context on all chemicals', function(){
   var Plasma = require("../index")
   it("invokes class method via onAll and keeps its context binded", function(done){
     var instance  = new Plasma()
-    var Class1 = function (plasma) {
-      plasma.on(['c1', 'c2'], this.handleAllMethod, this)
+    var Class1 = function () {
       this.value = true
     }
     Class1.prototype.handleAllMethod = function (c1, c2) {
@@ -12,15 +11,15 @@ describe('maintain class method context on all chemicals', function(){
       expect(this.value).toBe(true)
       done()
     }
-    var classInstance = new Class1(instance)
+    var classInstance = new Class1()
+    instance.on(['c1', 'c2'], classInstance.handleAllMethod, classInstance)
     instance.emit('c1')
     instance.emit('c2')
   })
 
   it('invokes class method via on and keeps its context binded', function(done) {
     var instance  = new Plasma()
-    var Class2 = function (plasma) {
-      plasma.on('c1', this.handlerMethod, this)
+    var Class2 = function () {
       this.value = true
     }
     Class2.prototype.handlerMethod = function (c1) {
@@ -28,7 +27,23 @@ describe('maintain class method context on all chemicals', function(){
       expect(this.value).toBe(true)
       done()
     }
-    var classInstance = new Class2(instance)
+    var classInstance = new Class2()
+    instance.on('c1', classInstance.handlerMethod, classInstance)
     instance.emit('c1')
+  })
+
+  it('invokes a method with proper context after store', function (done) {
+    var instance  = new Plasma()
+    var Class3 = function () {
+      this.value = true
+    }
+    Class3.prototype.handlerMethod = function (c1) {
+      expect(c1.type).toBe('c1')
+      expect(this.value).toBe(true)
+      done()
+    }
+    var classInstance = new Class3()
+    instance.store('c1')
+    instance.on('c1', classInstance.handlerMethod, classInstance)
   })
 })

--- a/tests/context.spec.js
+++ b/tests/context.spec.js
@@ -3,12 +3,13 @@ describe('maintain class method context on all chemicals', function(){
   it("invokes class method via onAll and keeps its context binded", function(done){
     var instance  = new Plasma()
     var Class1 = function (plasma) {
-      plasma.on(['c1', 'c2'], this.handleAllMethod.bind(this))
+      plasma.on(['c1', 'c2'], this.handleAllMethod, this)
+      this.value = true
     }
     Class1.prototype.handleAllMethod = function (c1, c2) {
       expect(c1.type).toBe('c1')
       expect(c2.type).toBe('c2')
-      expect(this).toBe(classInstance)
+      expect(this.value).toBe(true)
       done()
     }
     var classInstance = new Class1(instance)
@@ -19,11 +20,12 @@ describe('maintain class method context on all chemicals', function(){
   it('invokes class method via on and keeps its context binded', function(done) {
     var instance  = new Plasma()
     var Class2 = function (plasma) {
-      plasma.on('c1', this.handlerMethod.bind(this))
+      plasma.on('c1', this.handlerMethod, this)
+      this.value = true
     }
     Class2.prototype.handlerMethod = function (c1) {
       expect(c1.type).toBe('c1')
-      expect(this).toBe(classInstance)
+      expect(this.value).toBe(true)
       done()
     }
     var classInstance = new Class2(instance)

--- a/tests/has.spec.js
+++ b/tests/has.spec.js
@@ -3,8 +3,8 @@ describe("plasma has feature", function(){
   var instance  = new Plasma()
   it("stores and has chemical", function(){
     instance.store({type: "c1"})
-    exect(instance.has({type: "c1"})).to.eq(true)
-    exect(instance.has({type: "c2"})).to.eq(false)
+    expect(instance.has({type: "c1"})).toBe(true)
+    expect(instance.has({type: "c2"})).toBe(false)
   })
 
 })

--- a/tests/off.spec.js
+++ b/tests/off.spec.js
@@ -4,6 +4,13 @@ describe("plasma off", function () {
   var handler = function () {
     throw new Error('should not happen')
   }
+  var handler2 = function () {
+    throw new Error('should not happen')
+  }
+  var Context = function () {}
+  Context.prototype.handler = function () {
+    throw new Error('should not happen')
+  }
   it("unregister listener", function () {
     instance.on('c1', handler)
     expect(instance.listeners.length).toBe(1)
@@ -18,5 +25,37 @@ describe("plasma off", function () {
     instance.off(handler)
     expect(instance.listeners.length).toBe(0)
     instance.emit('c1')
+  })
+  it('unregister listener by different handlers', function () {
+    instance.on('c1', handler)
+    instance.on('c1', handler2)
+    expect(instance.listeners.length).toBe(2)
+    instance.off(handler)
+    expect(instance.listeners.length).toBe(1)
+    instance.off(handler2)
+    expect(instance.listeners.length).toBe(0)
+  })
+  it('unregister listener by handler and context', function () {
+    var context1 = new Context()
+    var context2 = new Context()
+    instance.on('c1', context1.handler, context1)
+    instance.on('c1', context2.handler, context2)
+    expect(instance.listeners.length).toBe(2)
+    instance.off(context1.handler, context1)
+    expect(instance.listeners.length).toBe(1)
+    instance.off(context2.handler, context2)
+    expect(instance.listeners.length).toBe(0)
+  })
+
+  it('unregister listener by pattern and handler', function () {
+    var context1 = new Context()
+    var context2 = new Context()
+    instance.on('c1', context1.handler, context1)
+    instance.on('c1', context2.handler, context2)
+    expect(instance.listeners.length).toBe(2)
+    /instance.off('c1', context1.handler, context1)
+    expect(instance.listeners.length).toBe(1)
+    instance.off('c1', context2.handler, context2)
+    expect(instance.listeners.length).toBe(0)
   })
 })

--- a/tests/off.spec.js
+++ b/tests/off.spec.js
@@ -1,0 +1,22 @@
+describe("plasma off", function () {
+  var Plasma = require("../index")
+  var instance  = new Plasma()
+  var handler = function () {
+    throw new Error('should not happen')
+  }
+  it("unregister listener", function () {
+    instance.on('c1', handler)
+    expect(instance.listeners.length).toBe(1)
+    instance.off('c1', handler)
+    expect(instance.listeners.length).toBe(0)
+    instance.emit('c1')
+  })
+  it('unregister listener by handler only', function () {
+    instance.on('c1', handler)
+    instance.on('c1', handler)
+    expect(instance.listeners.length).toBe(2)
+    instance.off(handler)
+    expect(instance.listeners.length).toBe(0)
+    instance.emit('c1')
+  })
+})


### PR DESCRIPTION

**The release contains breaking changes towards v1.x.x**
Upgrade path requires removing `organic-plasma-feedback` decoration as feedback support is re-implemented in organic-plasma module

### Changed

- `plasma.on` - supports feedback callback
- `plasma.on(array)` - supports feedback callback
- `plasma.emit` - supports feedback callback, returns `true` Boolean value when chemical has been aggregated
- `plasma.off` - added additional support for single `handler` form
- `plasma.store` - supports String chemicals

### Fixed

- jasmine test specs
- plasma.emit to return true when chemical has been aggregated